### PR TITLE
Remove shebang, since these files are meant to be sourced

### DIFF
--- a/src/.bashrc
+++ b/src/.bashrc
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Initialization script for interactive bash shells.
 if [ -d "$HOME/.bashrc.d" ]; then
   for i in $HOME/.bashrc.d/*.bash; do

--- a/src/.bashrc.d/aliases.bash
+++ b/src/.bashrc.d/aliases.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 

--- a/src/.bashrc.d/completion.bash
+++ b/src/.bashrc.d/completion.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 

--- a/src/.bashrc.d/history.bash
+++ b/src/.bashrc.d/history.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 

--- a/src/.bashrc.d/prompt.bash
+++ b/src/.bashrc.d/prompt.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 

--- a/src/.bashrc.d/terminal.bash
+++ b/src/.bashrc.d/terminal.bash
@@ -1,9 +1,23 @@
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 
-# check the window size after each command and, if necessary,
-# update the values of LINES and COLUMNS.
+# Check window size after each command and update LINES and COLUMNS
 shopt -s checkwinsize
+
+# Automatically fix minor typos in "cd" directory names
+shopt -s cdspell
+
+# Include subdirectories when expanding "**" pattern
+shopt -s globstar
+
+# Do not search PATH when using "source" builtin
+shopt -u sourcepath
+
+# Notify when background jobs terminate
+set -o notify
+
+# Return exit status of failed command in pipeline
+set -o pipefail
 
 # Don't use ^D to exit
 set -o ignoreeof

--- a/src/.bashrc.d/terminal.bash
+++ b/src/.bashrc.d/terminal.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 


### PR DESCRIPTION
These files are meant to be sourced, not executed directly, and
therefore do not need the #!/bin/bash shebang.

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>