### PR TITLE
Source files relative to current script directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # https://kernel.org/pub/software/scm/git/docs/gitattributes.html#_end_of_line_conversion
-* text=auto
+* text=auto eol=lf

--- a/src/.bashrc
+++ b/src/.bashrc
@@ -1,8 +1,15 @@
 # Initialization script for interactive bash shells.
-if [ -d "$HOME/.bashrc.d" ]; then
-  for i in $HOME/.bashrc.d/*.bash; do
+
+# Source files relative to current script directory, so that changes can
+# be tested using "source .bashrc" from anywhere
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -d "$DIR/.bashrc.d" ]; then
+  for i in $DIR/.bashrc.d/*.bash; do
     if [ -r $i ]; then
-      . $i
+      source $i
+    else
+      echo "File '$i' is not readable; skipping"
     fi
   done
   unset i


### PR DESCRIPTION
This change searches paths relative to the currently-executing .bashrc script, rather than $HOME, enabling non-persistent testing of script changes.

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>