### PR TITLE
Add ~/.local/bin rather than ~/.bin to PATH

### DIFF
--- a/src/.bashrc.d/path.sh
+++ b/src/.bashrc.d/path.sh
@@ -18,7 +18,7 @@ add_if_exist () {
 }
 
 # Locally-installed scripts and utilities
-add_if_exist "${HOME}/.bin"
+add_if_exist "${HOME}/.local/bin"
 
 # Node.js scripts
 add_if_exist "${HOME}/.npm-packages/bin"


### PR DESCRIPTION
Use the executable directory defined in the XDG Base Directory
specification (~/.local/bin) as this is the standard on modern
Linux systems.

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>