### PR TITLE
feat: use full source and target paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,6 @@ set -o nounset
 
 echo "==> dotfile installation started"
 
-SOURCE=$PWD/src
-
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 # shellcheck source=lib/copy.sh
 . "$PROJECT_ROOT/lib/copy.sh"
@@ -21,33 +19,35 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 echo
 echo "--> Removing redundant/unnecessary files..."
 
-remove .bash_profile
+SOURCE="$PROJECT_ROOT/src"
+
+remove "$HOME/.bash_profile"
 
 # Install symbolic links for home directory, so that changes are reflected
 # in Git
 echo
 echo "--> Installing symbolic links to $HOME..."
 
-link "$SOURCE" .bashrc
-make_directory .bashrc.d
-link "$SOURCE" .bashrc.d/aliases.sh
-link "$SOURCE" .bashrc.d/completion.sh
-link "$SOURCE" .bashrc.d/history.sh
-link "$SOURCE" .bashrc.d/path.sh
-link "$SOURCE" .bashrc.d/prompt.sh
-link "$SOURCE" .bashrc.d/terminal.sh
+link "$SOURCE/.bashrc" "$HOME/.bashrc"
+make_directory "$HOME/.bashrc.d"
+link "$SOURCE/.bashrc.d/aliases.sh" "$HOME/.bashrc.d/aliases.sh"
+link "$SOURCE/.bashrc.d/completion.sh" "$HOME/.bashrc.d/completion.sh"
+link "$SOURCE/.bashrc.d/history.sh" "$HOME/.bashrc.d/history.sh"
+link "$SOURCE/.bashrc.d/path.sh" "$HOME/.bashrc.d/path.sh"
+link "$SOURCE/.bashrc.d/prompt.sh" "$HOME/.bashrc.d/prompt.sh"
+link "$SOURCE/.bashrc.d/terminal.sh" "$HOME/.bashrc.d/terminal.sh"
 
-link "$SOURCE" .gitconfig
+link "$SOURCE/.gitconfig" "$HOME/.gitconfig"
 
-link "$SOURCE" .inputrc
+link "$SOURCE/.inputrc" "$HOME/.inputrc"
 
-link "$SOURCE" .npmrc
-link "$SOURCE" .yarnrc
+link "$SOURCE/.npmrc" "$HOME/.npmrc"
+link "$SOURCE/.yarnrc" "$HOME/.yarnrc"
 
-link "$SOURCE" .profile
+link "$SOURCE/.profile" "$HOME/.profile"
 
-make_directory .ssh 700
-copy "$SOURCE" .ssh/config
+make_directory "$HOME/.ssh" 700
+copy "$SOURCE/.ssh/config" "$HOME/.ssh/config"
 
 echo
 echo "==> dotfile installation completed successfully"

--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -5,14 +5,14 @@ set -o nounset
 
 copy() {
     local source="$1"
-    local name="$2"
+    local target="$2"
     local mode=${3:-0644}
 
     # If the installed file is newer than the source one, do nothing
-    if [ -n "$(find -L "$HOME/$name" -prune -newer "$source/$name")" ]; then
-        echo "--- Existing file $HOME/$name is newer than source $source/$name; skipping" >&2
+    if [ -n "$(find -L "$target" -prune -newer "$source")" ]; then
+        echo "--- Existing file $target is newer than source $source; skipping" >&2
         return
     fi
 
-    install --verbose --compare --backup --mode="$mode" --no-target-directory "$source/$name" "$HOME/$name"
+    install --verbose --compare --backup --mode="$mode" --no-target-directory "$source" "$target"
 }

--- a/lib/link.sh
+++ b/lib/link.sh
@@ -5,16 +5,17 @@ set -o nounset
 
 link() {
     local source="$1"
-    local name="$2"
+    local target="$2"
 
-    if [ -L "$HOME/$name" ]; then
+    if [ -L "$target" ]; then
         # If the symbolic link is already installed and points to the correct
         # location, do nothing
-        target=$(readlink "$HOME/$name")
-        if [ "$target" = "$source/$name" ]; then
+        local destination
+        destination=$(readlink "$source")
+        if [ "$destination" = "$source" ]; then
             return
         fi
     fi
 
-    ln --symbolic --verbose --backup "$source/$name" "$HOME/$name"
+    ln --symbolic --verbose --backup "$source" "$target"
 }

--- a/lib/make_directory.sh
+++ b/lib/make_directory.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 
 make_directory() {
-    local name="$1"
+    local target="$1"
     local mode=${2:-0755}
 
-    if [ -d "$HOME"/"$name" ]; then
+    if [ -d "$target" ]; then
         return
     fi
 
@@ -16,8 +16,8 @@ make_directory() {
 
     if [ "$OS" = "Msys" ]; then
         # mkdir on Windows fails with --mode
-        mkdir --verbose "$HOME"/"$name"
+        mkdir --verbose "$target"
     else
-        mkdir --verbose --mode="$mode" "$HOME"/"$name"
+        mkdir --verbose --mode="$mode" "$target"
     fi
 }

--- a/lib/remove.sh
+++ b/lib/remove.sh
@@ -4,11 +4,11 @@ set -o errexit
 set -o nounset
 
 remove() {
-    name="$1"
+    target="$1"
 
-    if [ ! -e "$HOME/$name" ]; then
+    if [ ! -e "$target" ]; then
         return
     fi
 
-    rm --verbose "$HOME/$name"
+    rm --verbose "$target"
 }


### PR DESCRIPTION
Use full paths to file, so that we can use the functions to
install into system directories rather than just the home directory.